### PR TITLE
The timeout seconds should be shorter than 60 seconds

### DIFF
--- a/bukkit/src/main/java/co/aikar/taskchain/BukkitTaskChainFactory.java
+++ b/bukkit/src/main/java/co/aikar/taskchain/BukkitTaskChainFactory.java
@@ -96,7 +96,7 @@ public class BukkitTaskChainFactory extends TaskChainFactory {
                 @EventHandler
                 public void onPluginDisable(PluginDisableEvent event) {
                     if (event.getPlugin().equals(plugin)) {
-                        factory.shutdown(60, TimeUnit.SECONDS);
+                        factory.shutdown(30, TimeUnit.SECONDS);
                     }
                 }
             }, plugin);


### PR DESCRIPTION
In Paper, the default is 60 seconds until the server is considered to be completely stopped and a forced shutdown is performed. If this value and the timeout of TaskChain are the same or TaskChain is longer, it may cause an unexpected forced shutdown. Therefore, the time to timeout for TaskChain should be shorter than 60 seconds.